### PR TITLE
Merge CDCgov readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,69 @@
-# NIOSH Mining
+# NIOSH Mining Open Source Software
 
-This is the Github landing page for projects released by the [NIOSH mining program](https://www.cdc.gov/niosh/mining/index.html). We are excited to share some of our code and would encourage you to checkout, use, and contribute to our projects.
-
-## Terms of Use
-
-NIOSH github projects follow the [CDC privacy policy](https://www.cdc.gov/Other/privacy.html) and [other policies](https://www.cdc.gov/Other/policies.html) where applicable.
+This is the Github landing page for projects released by the [National Institute for Occupational Safety and Health](https://www.cdc.gov/niosh/index.htm)'s [mining program](https://www.cdc.gov/niosh/mining/index.html). NIOSH is a member of the [Centers for Disease Control](https://www.cdc.gov/). We encourage you to explore, use, and contribute to our projects.
 
 ## Disclaimer
 
-Mention of any company or product does not constitute endorsement by the National Institute for Occupational Safety and Health (NIOSH). In addition, citations to Web sites external to NIOSH do not constitute NIOSH endorsement of the sponsoring organizations or their programs or products. Furthermore, NIOSH is not responsible for the content of these Web sites. All Web addresses referenced in this document were accessible as of the publication date.
+This repository was created for use by the NIOSH mining program to collaborate on health/safety related projects in support of the [NIOSH](https://www.cdc.gov/niosh/about/default.html) and [CDC](https://www.cdc.gov/about/organization/mission.htm) missions.  GitHub is not hosted by the CDC, but is a third party website used by NIOSH and its partners to share information and collaborate on software. NIOSH use of GitHub does not imply an endorsement of any one particular service, product, or enterprise. 
 
 NIOSH-developed software is provided "AS IS" without warranty of any kind including express or implied warranties of merchantability or fitness for a particular purpose. By acceptance and use of this software, which is conveyed to the user without consideration by NIOSH, the user expressly waives any and all claims for damage and/or suits for personal injury or property damage resulting from any direct, indirect, incidental, special or consequential damages, or damages for loss of profits, revenue, data or property use, incurred by you or any third party, whether in an action in contract or tort, arising from your access to, or use of, this software in whole or in part.
 
-No further development or upgrades for this software are planned. Any questions concerning this product can be directed to the NIOSH Mining Program via email at mining@cdc.gov.
+No further development or upgrades for NIOSH-mining software are planned. Any questions concerning can be directed to the NIOSH Mining Program via email at mining@cdc.gov.
+
+## Applicable Documents
+
+* [Open Practices](open_practices.md)
+* [Rules of Behavior](rules_of_behavior.md)
+* [Disclaimer](DISCLAIMER.md)
+* [Code of Conduct](code-of-conduct.md)
+
+## Public Domain Standard Notice
+
+All NIOSH-mining repositories constitute works of the United States Government and are not
+subject to domestic copyright protection under 17 USC § 105. All NIOSH-mining code is in
+the public domain within the United States, and copyright and related rights in
+the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+All contributions to NIOSH-mining repositories will be released under the CC0 dedication. By
+submitting a pull request you are agreeing to comply with this waiver of
+copyright interest.
+
+## License Standard Notice
+
+NIOSH-mining repositories are licensed under various [osi approved open source liscences](https://opensource.org/licenses). 
+See notices on individual repos for license specifics.
+
+## Privacy Standard Notice
+
+NIOSH-mining repositories contain only non-sensitive, publicly available data and
+information. All material and community participation is covered by the
+[Disclaimer](https://github.com/CDCgov/template/blob/master/DISCLAIMER.md)
+and [Code of Conduct](https://github.com/CDCgov/template/blob/master/code-of-conduct.md).
+For more information about CDC's privacy policy, please visit [http://www.cdc.gov/other/privacy.html](https://www.cdc.gov/other/privacy.html).
+
+## Contributing Standard Notice
+
+Anyone is encouraged to contribute NIOSH-mining repositories by [forking](https://help.github.com/articles/fork-a-repo)
+and submitting a pull request. (If you are new to GitHub, you might start with a
+[basic tutorial](https://help.github.com/articles/set-up-git).) By contributing,
+you grant a world-wide, royalty-free, perpetual, irrevocable,
+non-exclusive, transferable license to all users under the terms of the project's license.
+
+All comments, messages, pull requests, and other submissions received through
+NIOSH may be subject to applicable federal law, including but not limited to the
+Federal Records Act, and may be archived. Learn more at [http://www.cdc.gov/other/privacy.html](http://www.cdc.gov/other/privacy.html).
+
+## Records Management Standard Notice
+
+This NIOSH-mining repos are not a source of government records, but are copies to increase
+collaboration and collaborative potential. All government records will be
+published through the [CDC web site](http://www.cdc.gov).
+
+## Additional Standard Notices
+
+Please refer to [CDC's Template Repository](https://github.com/CDCgov/template)
+for more information about [contributing to this repository](https://github.com/CDCgov/template/blob/master/CONTRIBUTING.md),
+[public domain notices and disclaimers](https://github.com/CDCgov/template/blob/master/DISCLAIMER.md),
+and [code of conduct](https://github.com/CDCgov/template/blob/master/code-of-conduct.md).
+
+
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NIOSH Mining Open Source Software
 
 This is the Github landing page for projects released by the [National Institute for Occupational Safety and Health](https://www.cdc.gov/niosh/index.htm)'s [mining program](https://www.cdc.gov/niosh/mining/index.html). NIOSH is a member of the [Centers for Disease Control](https://www.cdc.gov/). We encourage you to explore, use, and contribute to our projects.
-
+https://github.com/cdcgov/template
 ## Disclaimer
 
 This repository was created for use by the NIOSH mining program to collaborate on health/safety related projects in support of the [NIOSH](https://www.cdc.gov/niosh/about/default.html) and [CDC](https://www.cdc.gov/about/organization/mission.htm) missions.  GitHub is not hosted by the CDC, but is a third party website used by NIOSH and its partners to share information and collaborate on software. NIOSH use of GitHub does not imply an endorsement of any one particular service, product, or enterprise. 
@@ -12,10 +12,10 @@ No further development or upgrades for NIOSH-mining software are planned. Any qu
 
 ## Applicable Documents
 
-* [Open Practices](open_practices.md)
-* [Rules of Behavior](rules_of_behavior.md)
-* [Disclaimer](DISCLAIMER.md)
-* [Code of Conduct](code-of-conduct.md)
+* [Open Practices](https://github.com/cdcgov/template/open_practices.md)
+* [Rules of Behavior](https://github.com/cdcgov/template/rules_of_behavior.md)
+* [Disclaimer](https://github.com/cdcgov/template/DISCLAIMER.md)
+* [Code of Conduct](https://github.com/cdcgov/template/code-of-conduct.md)
 
 ## Public Domain Standard Notice
 


### PR DESCRIPTION
I have attempted to merge the NIOSH readme and CDC gov readme to cover all the bafflegab (disclaimers, notices, etc) into one document we can link to from each repository, just as we were doing before. The new readme provides links to the documents on cdcgov/template documents.